### PR TITLE
Test and document all supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 install:
   - pip install nose

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,16 @@ This is a pure Python library.
           'License :: OSI Approved :: MIT License',
           'Programming Language :: Python',
           'Operating System :: OS Independent',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.6',
           'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Topic :: Multimedia :: Graphics'
      ]


### PR DESCRIPTION
Added Python 3.6 to Travis CI test matrix.

Added all supported Pythons to list of trove classifiers. This helps user know, at a glance, if the library is suitable for integrating with a project.

Added:

- General Python support
- General Python 2 support
- General Python 3 support
- Python 3.6 support
- CPython support