### PR TITLE
Enable pip cache in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 python:
   - "2.6"
   - "2.7"


### PR DESCRIPTION
Slightly speed up builds and reduce load on PyPI servers.

For more information, see:

https://docs.travis-ci.com/user/caching/#pip-cache