### PR TITLE
Skip FFC4, FFC8, FFCC markers

### DIFF
--- a/imagesize.py
+++ b/imagesize.py
@@ -72,7 +72,7 @@ def get(filepath):
                 fhandle.seek(0) # Read 0xff next
                 size = 2
                 ftype = 0
-                while not 0xc0 <= ftype <= 0xcf:
+                while not 0xc0 <= ftype <= 0xcf or ftype in [0xc4, 0xc8, 0xcc]:
                     fhandle.seek(size, 1)
                     byte = fhandle.read(1)
                     while ord(byte) == 0xff:


### PR DESCRIPTION
From [this post](http://sqlanywhere.blogspot.co.nz/2008/12/jpeg-width-and-height.html): blocks with these markers don't have the image size and should be skipped. My phone produces photos with an FFC4 block, so I get incorrect results.