### PR TITLE
Make sure *.pyc files are not included in the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE.rst
-graft test
+include test/*.py
+include test/images/*


### PR DESCRIPTION
The current tarball on PyPI contains unwanted files:
- `test/.DS_Store`
- `test/__pycache__/__init__.cpython-36.pyc`
- `test/__pycache__/test_get.cpython-36.pyc`

This pull request modifies `MANIFEST.in` to make sure only `*.py` and test images are included under `test/`.

How to test: run `python3 setup.py test sdist`, the output should be like following:
```
running sdist
...
copying test/__init__.py -> imagesize-1.1.0/test
copying test/test_get.py -> imagesize-1.1.0/test
copying test/images/multipage_tiff_example.tif -> imagesize-1.1.0/test/images
copying test/images/test.gif -> imagesize-1.1.0/test/images
copying test/images/test.jp2 -> imagesize-1.1.0/test/images
copying test/images/test.jpg -> imagesize-1.1.0/test/images
copying test/images/test.png -> imagesize-1.1.0/test/images
copying test/images/test.tiff -> imagesize-1.1.0/test/images
```

And there should be no other files under `test/`.