### PR TITLE
Fix spelling of word “Endian”

### DIFF
--- a/imagesize.py
+++ b/imagesize.py
@@ -108,7 +108,7 @@ def get(filepath):
                 height, width = struct.unpack('>LL', fhandle.read(8))
             except struct.error:
                 raise ValueError("Invalid JPEG2000 file")
-        # handle big endien TIFF
+        # handle big endian TIFF
         elif size >= 8 and head.startswith(b"\x4d\x4d\x00\x2a"):
             offset = struct.unpack('>L', head[4:8])[0]
             fhandle.seek(offset)

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -28,12 +28,12 @@ class GetTest(unittest.TestCase):
         self.assertEqual(width, 802)
         self.assertEqual(height, 670)
 
-    def test_bigendien_tiff(self):
+    def test_bigendian_tiff(self):
         width, height = imagesize.get(os.path.join(imagedir, "test.tiff"))
         self.assertEqual(width, 802)
         self.assertEqual(height, 670)
 
-    def test_littleendien_tiff(self):
+    def test_littleendian_tiff(self):
         width, height = imagesize.get(os.path.join(imagedir, "multipage_tiff_example.tif"))
         self.assertEqual(width, 800)
         self.assertEqual(height, 600)


### PR DESCRIPTION
See e.g. <https://en.wiktionary.org/wiki/endian>.