### PR TITLE
Remove dependency of unmaintained nose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.egg-info
 *.pyc
 __pycache__
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,4 @@ python:
   - "3.7"
   - "pypy2.7-6.0"
   - "pypy3.5-6.0"
-install:
-  - pip install nose
-script: nosetests
+script: python setup.py test


### PR DESCRIPTION
The nose project has ceased development. The last commit is from Mar 3, 2016. From their docs page:

https://nose.readthedocs.io/

> Note to Users
>
> Nose has been in maintenance mode for the past several years and will likely cease without a new person/team to take over maintainership. New projects should consider using Nose2, py.test, or just plain unittest/unittest2.

Simplify tests by using the stdlib unittest. One fewer dependency.