### PR TITLE
Support paths as pathlib.Path (or anything convertible to str)

### DIFF
--- a/imagesize.py
+++ b/imagesize.py
@@ -57,6 +57,7 @@ def get(filepath):
     Return (width, height) for a given img file content
     no requirements
     :type filepath: Union[str, pathlib.Path]
+    :rtype Tuple[int, int]
     """
     height = -1
     width = -1
@@ -154,9 +155,10 @@ def get(filepath):
 
 def getDPI(filepath):
     """
-    Return (width, height) for a given img file content
+    Return (x DPI, y DPI) for a given img file content
     no requirements
     :type filepath: Union[str, pathlib.Path]
+    :rtype Tuple[int, int]
     """
     xDPI = -1
     yDPI = -1

--- a/imagesize.py
+++ b/imagesize.py
@@ -56,11 +56,12 @@ def get(filepath):
     """
     Return (width, height) for a given img file content
     no requirements
+    :type filepath: Union[str, pathlib.Path]
     """
     height = -1
     width = -1
 
-    with open(filepath, 'rb') as fhandle:
+    with open(str(filepath), 'rb') as fhandle:
         head = fhandle.read(24)
         size = len(head)
         # handle GIFs
@@ -155,10 +156,11 @@ def getDPI(filepath):
     """
     Return (width, height) for a given img file content
     no requirements
+    :type filepath: Union[str, pathlib.Path]
     """
     xDPI = -1
     yDPI = -1
-    with open(filepath, 'rb') as fhandle:
+    with open(str(filepath), 'rb') as fhandle:
         head = fhandle.read(24)
         size = len(head)
         # handle GIFs


### PR DESCRIPTION
Python 3 code commonly represents paths as [pathlib `Path` objects](https://docs.python.org/3/library/pathlib.html), rather than `str`s. This patch makes `get()` and `getDPI()` silently accept `Path` objects, in a way that's backward compatible with Python 2.

In my local testing, the perf cost was way below the noise threshold.