### PR TITLE
 Remove deprecated use of 'setup.py test'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ matrix:
       python: "pypy2.7-6.0"
     - arch: amd64
       python: "pypy3.5-6.0"
-script: python setup.py test
+script: python -m unittest discover

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ This is a pure Python library.
       url='https://github.com/shibukawa/imagesize_py',
       license="MIT",
       py_modules=['imagesize'],
-      test_suite='test',
       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Since setuptools v41.5.0 (27 Oct 2019), the 'test' command is formally
deprecated and should not be used. Now use unittest as the test entry
point.