### PR TITLE
Add tests for the getDPI() function

### DIFF
--- a/imagesize.py
+++ b/imagesize.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import re
 import struct
 from xml.etree import ElementTree
@@ -269,13 +270,13 @@ def getDPI(filepath):
                     print("headerSize", headerSize)
                     boxHeader = fhandle.read(8)
                     boxType = boxHeader[4:]
-                    print(boxType)
-                    if boxType == 'res ':  # find resolution super box
+                    print(boxType.decode('ascii'))
+                    if boxType == b'res ':  # find resolution super box
                         foundResBox = True
                         headerSize -= 8
                         print("found res super box")
                         break
-                    print("@1", boxHeader)
+                    print("@1", repr(boxHeader))
                     boxSize, = struct.unpack('>L', boxHeader[:4])
                     print("boxSize", boxSize)
                     fhandle.seek(boxSize - 8, 1)
@@ -285,7 +286,7 @@ def getDPI(filepath):
                         boxHeader = fhandle.read(8)
                         boxType = boxHeader[4:]
                         print(boxType)
-                        if boxType == 'resd':  # Display resolution box
+                        if boxType == b'resd':  # Display resolution box
                             print("@2")
                             yDensity, xDensity, yUnit, xUnit = struct.unpack(">HHBB", fhandle.read(10))
                             xDPI = _convertToDPI(xDensity, xUnit)

--- a/test/test_getdpi.py
+++ b/test/test_getdpi.py
@@ -1,0 +1,42 @@
+import unittest
+import os
+import imagesize
+
+imagedir = os.path.join(os.path.dirname(__file__), "images")
+
+
+class GetDPITest(unittest.TestCase):
+    def test_png(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.png"))
+        self.assertEqual(xdpi, 72)
+        self.assertEqual(ydpi, 72)
+
+    def test_jpeg(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.jpg"))
+        self.assertEqual(xdpi, 72)
+        self.assertEqual(ydpi, 72)
+
+    def test_jpeg2000(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.jp2"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_gif(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.gif"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_bigendian_tiff(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.tiff"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_svg(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.svg"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_littleendian_tiff(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "multipage_tiff_example.tif"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)


### PR DESCRIPTION
The test revealed str/bytes mixups in Python 3. They have been fixed.