### PR TITLE
Fix handling of different path types

### DIFF
--- a/imagesize.py
+++ b/imagesize.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import re
 import struct
 from xml.etree import ElementTree
@@ -269,13 +270,13 @@ def getDPI(filepath):
                     print("headerSize", headerSize)
                     boxHeader = fhandle.read(8)
                     boxType = boxHeader[4:]
-                    print(boxType)
-                    if boxType == 'res ':  # find resolution super box
+                    print(boxType.decode('ascii'))
+                    if boxType == b'res ':  # find resolution super box
                         foundResBox = True
                         headerSize -= 8
                         print("found res super box")
                         break
-                    print("@1", boxHeader)
+                    print("@1", repr(boxHeader))
                     boxSize, = struct.unpack('>L', boxHeader[:4])
                     print("boxSize", boxSize)
                     fhandle.seek(boxSize - 8, 1)
@@ -285,7 +286,7 @@ def getDPI(filepath):
                         boxHeader = fhandle.read(8)
                         boxType = boxHeader[4:]
                         print(boxType)
-                        if boxType == 'resd':  # Display resolution box
+                        if boxType == b'resd':  # Display resolution box
                             print("@2")
                             yDensity, xDensity, yUnit, xUnit = struct.unpack(">HHBB", fhandle.read(10))
                             xDPI = _convertToDPI(xDensity, xUnit)

--- a/imagesize.py
+++ b/imagesize.py
@@ -83,13 +83,16 @@ def get(filepath):
     """
     Return (width, height) for a given img file content
     no requirements
-    :type filepath: Union[str, pathlib.Path]
+    :type filepath: Union[bytes, str, pathlib.Path]
     :rtype Tuple[int, int]
     """
     height = -1
     width = -1
 
-    with open(str(filepath), 'rb') as fhandle:
+    if not isinstance(filepath, bytes):
+        filepath = str(filepath)
+
+    with open(filepath, 'rb') as fhandle:
         head = fhandle.read(24)
         size = len(head)
         # handle GIFs
@@ -193,12 +196,16 @@ def getDPI(filepath):
     """
     Return (x DPI, y DPI) for a given img file content
     no requirements
-    :type filepath: Union[str, pathlib.Path]
+    :type filepath: Union[bytes, str, pathlib.Path]
     :rtype Tuple[int, int]
     """
     xDPI = -1
     yDPI = -1
-    with open(str(filepath), 'rb') as fhandle:
+
+    if not isinstance(filepath, bytes):
+        filepath = str(filepath)
+
+    with open(filepath, 'rb') as fhandle:
         head = fhandle.read(24)
         size = len(head)
         # handle GIFs

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -4,7 +4,14 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import imagesize
 
+try:
+    from pathlib import Path
+except ImportError:
+    # Python 2
+    Path = None
+
 imagedir = os.path.join(os.path.dirname(__file__), "images")
+imagedir_bytes = imagedir.encode("utf-8")
 
 
 class GetTest(unittest.TestCase):
@@ -40,5 +47,82 @@ class GetTest(unittest.TestCase):
 
     def test_littleendian_tiff(self):
         width, height = imagesize.get(os.path.join(imagedir, "multipage_tiff_example.tif"))
+        self.assertEqual(width, 800)
+        self.assertEqual(height, 600)
+
+    def test_load_png_bytes(self):
+        width, height = imagesize.get(os.path.join(imagedir_bytes, b"test.png"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    def test_load_jpeg_bytes(self):
+        width, height = imagesize.get(os.path.join(imagedir_bytes, b"test.jpg"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    def test_load_jpeg2000_bytes(self):
+        width, height = imagesize.get(os.path.join(imagedir_bytes, b"test.jp2"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    def test_load_gif_bytes(self):
+        width, height = imagesize.get(os.path.join(imagedir_bytes, b"test.gif"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    def test_bigendian_tiff_bytes(self):
+        width, height = imagesize.get(os.path.join(imagedir_bytes, b"test.tiff"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    def test_load_svg_bytes(self):
+        width, height = imagesize.get(os.path.join(imagedir_bytes, b"test.svg"))
+        self.assertEqual(width, 90)
+        self.assertEqual(height, 60)
+
+    def test_littleendian_tiff_bytes(self):
+        width, height = imagesize.get(os.path.join(imagedir_bytes, b"multipage_tiff_example.tif"))
+        self.assertEqual(width, 800)
+        self.assertEqual(height, 600)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_load_png_path(self):
+        width, height = imagesize.get(Path(imagedir, "test.png"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_load_jpeg_path(self):
+        width, height = imagesize.get(Path(imagedir, "test.jpg"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_load_jpeg2000_path(self):
+        width, height = imagesize.get(Path(imagedir, "test.jp2"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_load_gif_path(self):
+        width, height = imagesize.get(Path(imagedir, "test.gif"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_bigendian_tiff_path(self):
+        width, height = imagesize.get(Path(imagedir, "test.tiff"))
+        self.assertEqual(width, 802)
+        self.assertEqual(height, 670)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_load_svg_path(self):
+        width, height = imagesize.get(Path(imagedir, "test.svg"))
+        self.assertEqual(width, 90)
+        self.assertEqual(height, 60)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_littleendian_tiff_path(self):
+        width, height = imagesize.get(Path(imagedir, "multipage_tiff_example.tif"))
         self.assertEqual(width, 800)
         self.assertEqual(height, 600)

--- a/test/test_getdpi.py
+++ b/test/test_getdpi.py
@@ -2,7 +2,15 @@ import unittest
 import os
 import imagesize
 
+try:
+    from pathlib import Path
+except ImportError:
+    # Python 2
+    Path = None
+
+
 imagedir = os.path.join(os.path.dirname(__file__), "images")
+imagedir_bytes = imagedir.encode("utf-8")
 
 
 class GetDPITest(unittest.TestCase):
@@ -38,5 +46,82 @@ class GetDPITest(unittest.TestCase):
 
     def test_littleendian_tiff(self):
         xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "multipage_tiff_example.tif"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_png_bytes(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir_bytes, b"test.png"))
+        self.assertEqual(xdpi, 72)
+        self.assertEqual(ydpi, 72)
+
+    def test_jpeg_bytes(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir_bytes, b"test.jpg"))
+        self.assertEqual(xdpi, 72)
+        self.assertEqual(ydpi, 72)
+
+    def test_jpeg2000_bytes(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir_bytes, b"test.jp2"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_gif_bytes(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir_bytes, b"test.gif"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_bigendian_tiff_bytes(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir_bytes, b"test.tiff"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_svg_bytes(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir_bytes, b"test.svg"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_littleendian_tiff_bytes(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir_bytes, b"multipage_tiff_example.tif"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_png_path(self):
+        xdpi, ydpi = imagesize.getDPI(Path(imagedir, "test.png"))
+        self.assertEqual(xdpi, 72)
+        self.assertEqual(ydpi, 72)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_jpeg_path(self):
+        xdpi, ydpi = imagesize.getDPI(Path(imagedir, "test.jpg"))
+        self.assertEqual(xdpi, 72)
+        self.assertEqual(ydpi, 72)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_jpeg2000_path(self):
+        xdpi, ydpi = imagesize.getDPI(Path(imagedir, "test.jp2"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_gif_path(self):
+        xdpi, ydpi = imagesize.getDPI(Path(imagedir, "test.gif"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_bigendian_tiff_path(self):
+        xdpi, ydpi = imagesize.getDPI(Path(imagedir, "test.tiff"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_svg_path(self):
+        xdpi, ydpi = imagesize.getDPI(Path(imagedir, "test.svg"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    @unittest.skipIf(Path is None, "requires pathlib support")
+    def test_littleendian_tiff_path(self):
+        xdpi, ydpi = imagesize.getDPI(Path(imagedir, "multipage_tiff_example.tif"))
         self.assertEqual(xdpi, -1)
         self.assertEqual(ydpi, -1)

--- a/test/test_getdpi.py
+++ b/test/test_getdpi.py
@@ -1,0 +1,42 @@
+import unittest
+import os
+import imagesize
+
+imagedir = os.path.join(os.path.dirname(__file__), "images")
+
+
+class GetDPITest(unittest.TestCase):
+    def test_png(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.png"))
+        self.assertEqual(xdpi, 72)
+        self.assertEqual(ydpi, 72)
+
+    def test_jpeg(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.jpg"))
+        self.assertEqual(xdpi, 72)
+        self.assertEqual(ydpi, 72)
+
+    def test_jpeg2000(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.jp2"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_gif(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.gif"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_bigendian_tiff(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.tiff"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_svg(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "test.svg"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)
+
+    def test_littleendian_tiff(self):
+        xdpi, ydpi = imagesize.getDPI(os.path.join(imagedir, "multipage_tiff_example.tif"))
+        self.assertEqual(xdpi, -1)
+        self.assertEqual(ydpi, -1)


### PR DESCRIPTION
In Python, a path can normally be either type `bytes`, `str`, or `pathlib.Path`. Coercing a `bytes` object to `str` results in using the `repr` value.
    
Add tests for all path types.