### PR TITLE
SVG Performance

### DIFF
--- a/imagesize.py
+++ b/imagesize.py
@@ -176,8 +176,9 @@ def get(filepath):
                 raise ValueError("Invalid TIFF file: width and/or height IDS entries are missing.")
         # handle SVGs
         elif size >= 5 and head.startswith(b'<?xml'):
+            fhandle.seek(0)
+            data = fhandle.read(1024)
             try:
-                data = fhandle.read(1024)
                 data = data.decode('utf-8')
                 width = re.search(r'[^-]width="(.*?)"', data).group(1)
                 height = re.search(r'[^-]height="(.*?)"', data).group(1)

--- a/imagesize.py
+++ b/imagesize.py
@@ -1,6 +1,5 @@
 import re
 import struct
-from xml.etree import ElementTree
 
 _UNIT_KM = -3
 _UNIT_100M = -2
@@ -178,12 +177,14 @@ def get(filepath):
         # handle SVGs
         elif size >= 5 and head.startswith(b'<?xml'):
             try:
-                fhandle.seek(0)
-                root = ElementTree.parse(fhandle).getroot()
-                width = _convertToPx(root.attrib["width"])
-                height = _convertToPx(root.attrib["height"])
+                data = fhandle.read(1024)
+                width = re.search(rb'[^-]width="(.*?)"', data).group(1).decode('utf-8')
+                height = re.search(rb'[^-]height="(.*?)"', data).group(1).decode('utf-8')
             except Exception:
                 raise ValueError("Invalid SVG file")
+
+            width = _convertToPx(width)
+            height = _convertToPx(height)
 
     return width, height
 

--- a/imagesize.py
+++ b/imagesize.py
@@ -55,27 +55,27 @@ def _convertToDPI(density, unit):
 
 
 def _convertToPx(value):
-    matched = re.match(r"(\d+)(?:\.\d)?([a-z]*)$", value)
+    matched = re.match(r"(\d+(?:\.\d+)?)?([a-z]*)$", value)
     if not matched:
         raise ValueError("unknown length value: %s" % value)
-    else:
-        length, unit = matched.groups()
-        if unit == "":
-            return int(length)
-        elif unit == "cm":
-            return int(length) * 96 / 2.54
-        elif unit == "mm":
-            return int(length) * 96 / 2.54 / 10
-        elif unit == "in":
-            return int(length) * 96
-        elif unit == "pc":
-            return int(length) * 96 / 6
-        elif unit == "pt":
-            return int(length) * 96 / 6
-        elif unit == "px":
-            return int(length)
-        else:
-            raise ValueError("unknown unit type: %s" % unit)
+
+    length, unit = matched.groups()
+    if unit == "":
+        return float(length)
+    elif unit == "cm":
+        return float(length) * 96 / 2.54
+    elif unit == "mm":
+        return float(length) * 96 / 2.54 / 10
+    elif unit == "in":
+        return float(length) * 96
+    elif unit == "pc":
+        return float(length) * 96 / 6
+    elif unit == "pt":
+        return float(length) * 96 / 6
+    elif unit == "px":
+        return float(length)
+
+    raise ValueError("unknown unit type: %s" % unit)
 
 
 def get(filepath):

--- a/imagesize.py
+++ b/imagesize.py
@@ -178,8 +178,9 @@ def get(filepath):
         elif size >= 5 and head.startswith(b'<?xml'):
             try:
                 data = fhandle.read(1024)
-                width = re.search(rb'[^-]width="(.*?)"', data).group(1).decode('utf-8')
-                height = re.search(rb'[^-]height="(.*?)"', data).group(1).decode('utf-8')
+                data = data.decode('utf-8')
+                width = re.search(r'[^-]width="(.*?)"', data).group(1)
+                height = re.search(r'[^-]height="(.*?)"', data).group(1)
             except Exception:
                 raise ValueError("Invalid SVG file")
 

--- a/imagesize.py
+++ b/imagesize.py
@@ -175,7 +175,7 @@ def get(filepath):
             if width == -1 or height == -1:
                 raise ValueError("Invalid TIFF file: width and/or height IDS entries are missing.")
         # handle SVGs
-        elif size >= 5 and head.startswith(b'<?xml'):
+        elif size >= 5 and (head.startswith(b'<?xml') or head.startswith(b'<svg')):
             fhandle.seek(0)
             data = fhandle.read(1024)
             try:

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -35,8 +35,8 @@ class GetTest(unittest.TestCase):
 
     def test_load_svg(self):
         width, height = imagesize.get(os.path.join(imagedir, "test.svg"))
-        self.assertEqual(width, 90)
-        self.assertEqual(height, 60)
+        self.assertEqual(width, 90.0)
+        self.assertEqual(height, 60.0)
 
     def test_littleendian_tiff(self):
         width, height = imagesize.get(os.path.join(imagedir, "multipage_tiff_example.tif"))


### PR DESCRIPTION
Improve the Performance of SVG Images by 40% (Python 2.7 78%) with the provided test.svg image.

- Fix throw error if width / height is a float
- Throw right ValueError instead of always "Invalid SVG File"