### PR TITLE
Handle SVG files with float dimensions

### DIFF
--- a/imagesize.py
+++ b/imagesize.py
@@ -55,7 +55,7 @@ def _convertToDPI(density, unit):
 
 
 def _convertToPx(value):
-    matched = re.match(r"(\d+)(?:\.\d)?([a-z]*)$", value)
+    matched = re.match(r"(\d+)(?:\.\d+)?([a-z]*)$", value)
     if not matched:
         raise ValueError("unknown length value: %s" % value)
     else:

--- a/test/images/test_float.svg
+++ b/test/images/test_float.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="80.12" width="102.345">
+    <circle cx="40" cy="40" r="24" style="stroke:#000000; fill:#ffffff"/>
+</svg>

--- a/test/images/test_float.svg
+++ b/test/images/test_float.svg
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="80.12" width="102.345">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     width="93.220428mm"
+     height="48.873943mm"
+     viewBox="0 0 93.220428 48.873943">
     <circle cx="40" cy="40" r="24" style="stroke:#000000; fill:#ffffff"/>
 </svg>

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -38,6 +38,11 @@ class GetTest(unittest.TestCase):
         self.assertEqual(width, 90)
         self.assertEqual(height, 60)
 
+    def test_load_float_svg(self):
+        width, height = imagesize.get(os.path.join(imagedir, "test_float.svg"))
+        self.assertEqual(width, 90)
+        self.assertEqual(height, 60)
+
     def test_littleendian_tiff(self):
         width, height = imagesize.get(os.path.join(imagedir, "multipage_tiff_example.tif"))
         self.assertEqual(width, 800)

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -40,8 +40,8 @@ class GetTest(unittest.TestCase):
 
     def test_load_float_svg(self):
         width, height = imagesize.get(os.path.join(imagedir, "test_float.svg"))
-        self.assertEqual(width, 102)
-        self.assertEqual(height, 80)
+        self.assertEqual(width, 351.496062992126)
+        self.assertEqual(height, 181.41732283464566)
 
     def test_littleendian_tiff(self):
         width, height = imagesize.get(os.path.join(imagedir, "multipage_tiff_example.tif"))

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -40,8 +40,8 @@ class GetTest(unittest.TestCase):
 
     def test_load_float_svg(self):
         width, height = imagesize.get(os.path.join(imagedir, "test_float.svg"))
-        self.assertEqual(width, 90)
-        self.assertEqual(height, 60)
+        self.assertEqual(width, 102)
+        self.assertEqual(height, 80)
 
     def test_littleendian_tiff(self):
         width, height = imagesize.get(os.path.join(imagedir, "multipage_tiff_example.tif"))


### PR DESCRIPTION
This small change of the conversion regex ensures handling SVG files that contain float dimension, e.g. when created with inkscape.