### PR TITLE
Remove upper cap on python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ This is a pure Python library.
       url='https://github.com/shibukawa/imagesize_py',
       license="MIT",
       packages=['imagesize'],
-      python_requires=">=3.10,<3.15",
+      python_requires=">=3.10",
 
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This is pure Python and works just fine on Python 3.15.

```
❯ python3.15 -m unittest
............................................................................
----------------------------------------------------------------------
Ran 76 tests in 0.015s

OK
```

There is no need for the cap.

Closes #85