### PR TITLE
fix: return positive height for BMP top-down bitmaps

### DIFF
--- a/imagesize/imagesize.py
+++ b/imagesize/imagesize.py
@@ -310,6 +310,7 @@ def _get_size(fhandle):
             raise ValueError("Unsupported WebP file")
     elif head.startswith(b'BM'):
         width, height = struct.unpack("<ll", head[18:26])
+        height = abs(height)
 
     return width, height
 

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -40,7 +40,7 @@ class GetTest(unittest.TestCase):
     def test_load_bmp(self):
         width, height = imagesize.get(bmpfile)
         self.assertEqual(width, 100)
-        self.assertEqual(abs(height), 300)
+        self.assertEqual(height, 300)
 
     def test_bigendian_tiff(self):
         width, height = imagesize.get(os.path.join(imagedir, "test.tiff"))
@@ -117,7 +117,7 @@ class GetTest(unittest.TestCase):
     def test_load_bmp_bytes(self):
         width, height = imagesize.get(bmpfile_bytes)
         self.assertEqual(width, 100)
-        self.assertEqual(abs(height), 300)
+        self.assertEqual(height, 300)
 
     def test_bigendian_tiff_bytes(self):
         width, height = imagesize.get(os.path.join(imagedir_bytes, b"test.tiff"))
@@ -187,7 +187,7 @@ class GetTest(unittest.TestCase):
     def test_load_bmp_path(self):
         width, height = imagesize.get(Path(bmpfile))
         self.assertEqual(width, 100)
-        self.assertEqual(abs(height), 300)
+        self.assertEqual(height, 300)
 
     def test_bigendian_tiff_path(self):
         width, height = imagesize.get(Path(imagedir, "test.tiff"))


### PR DESCRIPTION
BMP files encode bitmap orientation via a signed height field: positive
values indicate bottom-up (origin at bottom-left) and negative values
indicate top-down (origin at top-left). The actual pixel count is always
`abs(height)`.

Before this fix, `imagesize.get()` could return a negative height for
valid BMP files, which violates the expectation that image dimensions
are always positive. All other supported formats (PNG, JPEG, GIF, etc.)
already return positive dimensions.

**Changes:**
- Added `height = abs(height)` in the BMP parser path
- Updated existing tests to assert the actual positive height rather than
  working around the bug with `abs()` in the assertion

This pull request was prepared with the assistance of AI, under my direction and review.