### PR TITLE
Parse SVG width/height attributes that use single quotes

### DIFF
--- a/imagesize/imagesize.py
+++ b/imagesize/imagesize.py
@@ -254,8 +254,8 @@ def _get_size(fhandle):
         data = fhandle.read(1024)
         try:
             data = data.decode('utf-8')
-            width = re.search(r'[^-]width="(.*?)"', data).group(1)
-            height = re.search(r'[^-]height="(.*?)"', data).group(1)
+            width = re.search(r'''[^-]width=(["'])(.*?)\1''', data).group(2)
+            height = re.search(r'''[^-]height=(["'])(.*?)\1''', data).group(2)
         except Exception:
             raise ValueError("Invalid SVG file")
         width = _convertToPx(width)

--- a/test/test_get.py
+++ b/test/test_get.py
@@ -73,6 +73,41 @@ class GetTest(unittest.TestCase):
         self.assertEqual(width, 96)
         self.assertEqual(height, 48)
 
+    def test_load_svg_single_quoted_size(self):
+        from io import BytesIO
+
+        svg = b"<svg xmlns=\"http://www.w3.org/2000/svg\" width='90' height='60'></svg>"
+        width, height = imagesize.get(BytesIO(svg))
+        self.assertEqual(width, 90)
+        self.assertEqual(height, 60)
+
+    def test_load_svg_single_quoted_pt(self):
+        from io import BytesIO
+
+        svg = b"<svg xmlns=\"http://www.w3.org/2000/svg\" width='72pt' height='36pt'></svg>"
+        width, height = imagesize.get(BytesIO(svg))
+        self.assertEqual(width, 96)
+        self.assertEqual(height, 48)
+
+    def test_load_svg_ignores_stroke_width(self):
+        from io import BytesIO
+
+        svg = (
+            b"<svg xmlns=\"http://www.w3.org/2000/svg\" "
+            b"width='90' height='60' stroke-width=\"2\"></svg>"
+        )
+        width, height = imagesize.get(BytesIO(svg))
+        self.assertEqual(width, 90)
+        self.assertEqual(height, 60)
+
+    def test_load_svg_mismatched_quotes(self):
+        from io import BytesIO
+
+        svg = b"<svg xmlns='http://www.w3.org/2000/svg' width=\"90' height='60'></svg>"
+        width, height = imagesize.get(BytesIO(svg))
+        self.assertEqual(width, -1)
+        self.assertEqual(height, -1)
+
     def test_load_png_filelike(self):
         """ test_load_png_filelike
         """


### PR DESCRIPTION
## Summary

The SVG size parser only accepted double-quoted `width` and `height` attributes. Files that use single quotes, including SVGs produced by `dvisvgm`, therefore returned `(-1, -1)`. Downstream tools that need an intrinsic size (for example Sphinx’s image `:scale:` option) then cannot resize the image.

The regex now requires a matching pair of `'` or `"` (via a backreference), so mixed quotes such as `"90'` are still rejected. `stroke-width` continues to be ignored.

This was reported in #64. #73 fixed the `pt` to `px` conversion and closed #64, but the quote-matching regex was unchanged. The same pattern is still present in 2.0.0.

## References

- Fixes #64.
- Related to https://github.com/sphinx-doc/sphinx/issues/12415